### PR TITLE
test(server): authenticate gin API tests

### DIFF
--- a/src/l1/piccolod/docs/api/openapi.yaml
+++ b/src/l1/piccolod/docs/api/openapi.yaml
@@ -597,6 +597,18 @@ paths:
       summary: Logout
       responses:
         '200': { description: OK }
+  /auth/initialized:
+    get:
+      summary: Returns whether admin setup has been completed
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  initialized: { type: boolean }
   /auth/session:
     get:
       summary: Session status
@@ -917,15 +929,3 @@ components:
       type: apiKey
       in: header
       name: X-CSRF-Token
-  /auth/initialized:
-    get:
-      summary: Returns whether admin setup has been completed
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  initialized: { type: boolean }

--- a/src/l1/piccolod/internal/server/gin_app_handlers_test.go
+++ b/src/l1/piccolod/internal/server/gin_app_handlers_test.go
@@ -11,27 +11,31 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+
 	"piccolod/internal/api"
 	"piccolod/internal/app"
+	authpkg "piccolod/internal/auth"
 	"piccolod/internal/container"
-    "piccolod/internal/services"
-    "piccolod/internal/remote"
+	crypt "piccolod/internal/crypt"
+	"piccolod/internal/remote"
+	"piccolod/internal/services"
 )
 
 // TestGinAppAPI_Install tests POST /api/v1/apps endpoint with Gin
 func TestGinAppAPI_Install(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	
+
 	// Create temporary directory for filesystem state
 	tempDir, err := os.MkdirTemp("", "gin_app_api_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
-	
+
 	// Create test server with Gin
 	server := createGinTestServer(t, tempDir)
-	
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
+
 	tests := []struct {
 		name           string
 		method         string
@@ -76,10 +80,10 @@ environment:
 			expectError:    true,
 		},
 		{
-			name:        "install with invalid yaml",
-			method:      "POST",
-			contentType: "application/x-yaml",
-			body:        "invalid: yaml: content:",
+			name:           "install with invalid yaml",
+			method:         "POST",
+			contentType:    "application/x-yaml",
+			body:           "invalid: yaml: content:",
 			expectedStatus: http.StatusBadRequest,
 			expectError:    true,
 		},
@@ -89,30 +93,31 @@ environment:
 			contentType:    "application/x-yaml",
 			body:           "name: test",
 			expectedStatus: http.StatusNotFound, // Gin returns 404 for unregistered routes
-			expectError:    false, // 404 responses are plain text, not JSON
+			expectError:    false,               // 404 responses are plain text, not JSON
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			
+
 			var req *http.Request
 			if tt.body != "" {
 				req, _ = http.NewRequest(tt.method, "/api/v1/apps", strings.NewReader(tt.body))
 			} else {
 				req, _ = http.NewRequest(tt.method, "/api/v1/apps", nil)
 			}
-			
+
 			req.Header.Set("Content-Type", tt.contentType)
-			
+			attachAuth(req, sessionCookie, csrfToken)
+
 			server.router.ServeHTTP(w, req)
-			
+
 			if w.Code != tt.expectedStatus {
 				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
 				t.Logf("Response body: %s", w.Body.String())
 			}
-			
+
 			// Only check JSON for non-404 responses
 			if w.Code != http.StatusNotFound {
 				// Verify response is valid JSON
@@ -120,12 +125,12 @@ environment:
 				if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 					t.Errorf("Response is not valid JSON: %v", err)
 				}
-				
+
 				// Check error field matches expectation
 				if tt.expectError && response.Error == nil {
 					t.Error("Expected error in response but got none")
 				}
-				
+
 				if !tt.expectError && response.Error != nil {
 					t.Errorf("Expected no error but got: %+v", response.Error)
 				}
@@ -137,71 +142,74 @@ environment:
 // TestGinAppAPI_List tests GET /api/v1/apps endpoint with Gin
 func TestGinAppAPI_List(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	
+
 	// Create temporary directory for filesystem state
 	tempDir, err := os.MkdirTemp("", "gin_app_api_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
-	
+
 	// Create test server
 	server := createGinTestServer(t, tempDir)
-	
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
+
 	// Test empty list initially
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/v1/apps", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
 	}
-	
+
 	var response GinAppResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
-	
+
 	// Should return empty array
 	apps, ok := response.Data.([]interface{})
 	if !ok {
 		t.Fatalf("Expected array in response data")
 	}
-	
+
 	if len(apps) != 0 {
 		t.Errorf("Expected 0 apps, got %d", len(apps))
 	}
-	
+
 	// Install an app via the app manager directly
-    appDef := &api.AppDefinition{
-        Name:  "test-app",
-        Image: "nginx:alpine",
-        Type:  "user",
-        Listeners: []api.AppListener{{Name:"web", GuestPort:80}},
-    }
-	
+	appDef := &api.AppDefinition{
+		Name:      "test-app",
+		Image:     "nginx:alpine",
+		Type:      "user",
+		Listeners: []api.AppListener{{Name: "web", GuestPort: 80}},
+	}
+
 	_, err = server.appManager.Install(context.Background(), appDef)
 	if err != nil {
 		t.Fatalf("Failed to install app: %v", err)
 	}
-	
+
 	// Test list with one app
 	w = httptest.NewRecorder()
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
 	}
-	
+
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse response: %v", err)
 	}
-	
+
 	apps, ok = response.Data.([]interface{})
 	if !ok {
 		t.Fatalf("Expected array in response data")
 	}
-	
+
 	if len(apps) != 1 {
 		t.Errorf("Expected 1 app, got %d", len(apps))
 	}
@@ -210,30 +218,31 @@ func TestGinAppAPI_List(t *testing.T) {
 // TestGinAppAPI_GetApp tests GET /api/v1/apps/:name endpoint with Gin
 func TestGinAppAPI_GetApp(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	
+
 	// Create temporary directory for filesystem state
 	tempDir, err := os.MkdirTemp("", "gin_app_api_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
-	
+
 	// Create test server and install an app
 	server := createGinTestServer(t, tempDir)
-	
-    appDef := &api.AppDefinition{
-        Name:      "test-app",
-        Image:     "nginx:alpine",
-        Type:      "user",
-        Subdomain: "test",
-        Listeners: []api.AppListener{{Name:"web", GuestPort:80}},
-    }
-	
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
+
+	appDef := &api.AppDefinition{
+		Name:      "test-app",
+		Image:     "nginx:alpine",
+		Type:      "user",
+		Subdomain: "test",
+		Listeners: []api.AppListener{{Name: "web", GuestPort: 80}},
+	}
+
 	_, err = server.appManager.Install(context.Background(), appDef)
 	if err != nil {
 		t.Fatalf("Failed to install app: %v", err)
 	}
-	
+
 	tests := []struct {
 		name           string
 		appName        string
@@ -253,26 +262,27 @@ func TestGinAppAPI_GetApp(t *testing.T) {
 			expectError:    true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest("GET", "/api/v1/apps/"+tt.appName, nil)
+			attachAuth(req, sessionCookie, csrfToken)
 			server.router.ServeHTTP(w, req)
-			
+
 			if w.Code != tt.expectedStatus {
 				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
 			}
-			
+
 			var response GinAppResponse
 			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 				t.Errorf("Response is not valid JSON: %v", err)
 			}
-			
+
 			if tt.expectError && response.Error == nil {
 				t.Error("Expected error in response but got none")
 			}
-			
+
 			if !tt.expectError && response.Error != nil {
 				t.Errorf("Expected no error but got: %+v", response.Error)
 			}
@@ -283,29 +293,30 @@ func TestGinAppAPI_GetApp(t *testing.T) {
 // TestGinAppAPI_AppActions tests POST /api/v1/apps/:name/{action} endpoints with Gin
 func TestGinAppAPI_AppActions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	
+
 	// Create temporary directory for filesystem state
 	tempDir, err := os.MkdirTemp("", "gin_app_api_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
-	
+
 	// Create test server and install an app
 	server := createGinTestServer(t, tempDir)
-	
-    appDef := &api.AppDefinition{
-        Name:  "test-app",
-        Image: "alpine:latest",
-        Type:  "user",
-        Listeners: []api.AppListener{{Name:"web", GuestPort:80}},
-    }
-	
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
+
+	appDef := &api.AppDefinition{
+		Name:      "test-app",
+		Image:     "alpine:latest",
+		Type:      "user",
+		Listeners: []api.AppListener{{Name: "web", GuestPort: 80}},
+	}
+
 	_, err = server.appManager.Install(context.Background(), appDef)
 	if err != nil {
 		t.Fatalf("Failed to install app: %v", err)
 	}
-	
+
 	tests := []struct {
 		name           string
 		method         string
@@ -346,7 +357,7 @@ func TestGinAppAPI_AppActions(t *testing.T) {
 			method:         "GET",
 			url:            "/api/v1/apps/test-app/start",
 			expectedStatus: http.StatusNotFound, // Gin returns 404 for unregistered routes
-			expectError:    false, // 404 responses are plain text, not JSON
+			expectError:    false,               // 404 responses are plain text, not JSON
 		},
 		{
 			name:           "action on non-existent app",
@@ -356,29 +367,30 @@ func TestGinAppAPI_AppActions(t *testing.T) {
 			expectError:    true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest(tt.method, tt.url, nil)
+			attachAuth(req, sessionCookie, csrfToken)
 			server.router.ServeHTTP(w, req)
-			
+
 			if w.Code != tt.expectedStatus {
 				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
 				t.Logf("Response body: %s", w.Body.String())
 			}
-			
+
 			// Only check JSON for non-404 responses
 			if w.Code != http.StatusNotFound {
 				var response GinAppResponse
 				if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 					t.Errorf("Response is not valid JSON: %v", err)
 				}
-				
+
 				if tt.expectError && response.Error == nil {
 					t.Error("Expected error in response but got none")
 				}
-				
+
 				if !tt.expectError && response.Error != nil {
 					t.Errorf("Expected no error but got: %+v", response.Error)
 				}
@@ -390,18 +402,19 @@ func TestGinAppAPI_AppActions(t *testing.T) {
 // TestGinAppAPI_FullLifecycle tests complete app lifecycle via Gin HTTP API
 func TestGinAppAPI_FullLifecycle(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	
+
 	// Create temporary directory for filesystem state
 	tempDir, err := os.MkdirTemp("", "gin_app_api_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
-	
+
 	// Create test server
 	server := createGinTestServer(t, tempDir)
-	
-appYAML := `name: lifecycle-test
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
+
+	appYAML := `name: lifecycle-test
 image: docker.io/library/nginx:alpine
 type: user
 subdomain: lifecycle-test
@@ -412,99 +425,108 @@ listeners:
     protocol: http
 environment:
   TEST_ENV: "lifecycle"`
-	
+
 	// 1. Install app via HTTP API
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/api/v1/apps", strings.NewReader(appYAML))
 	req.Header.Set("Content-Type", "application/x-yaml")
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusCreated {
 		t.Fatalf("Failed to install app: status %d, body: %s", w.Code, w.Body.String())
 	}
-	
+
 	// 2. Verify app appears in list
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/v1/apps", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to list apps: status %d", w.Code)
 	}
-	
+
 	// 3. Get specific app details
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/v1/apps/lifecycle-test", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to get app details: status %d", w.Code)
 	}
-	
+
 	// 4. Start the app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/v1/apps/lifecycle-test/start", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to start app: status %d, body: %s", w.Code, w.Body.String())
 	}
-	
+
 	// 5. Enable the app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/v1/apps/lifecycle-test/enable", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to enable app: status %d", w.Code)
 	}
-	
+
 	// 6. Stop the app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/v1/apps/lifecycle-test/stop", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to stop app: status %d", w.Code)
 	}
-	
+
 	// 7. Disable the app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/api/v1/apps/lifecycle-test/disable", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to disable app: status %d", w.Code)
 	}
-	
+
 	// 8. Uninstall the app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("DELETE", "/api/v1/apps/lifecycle-test", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to uninstall app: status %d", w.Code)
 	}
-	
+
 	// 9. Verify app is gone
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("GET", "/api/v1/apps", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
-	
+
 	if w.Code != http.StatusOK {
 		t.Fatalf("Failed to list apps after uninstall: status %d", w.Code)
 	}
-	
+
 	var response GinAppResponse
 	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
 		t.Fatalf("Failed to parse final response: %v", err)
 	}
-	
+
 	apps, ok := response.Data.([]interface{})
 	if !ok {
 		t.Fatalf("Expected array in response data")
 	}
-	
+
 	if len(apps) != 0 {
 		t.Errorf("Expected 0 apps after full lifecycle, got %d", len(apps))
 	}
@@ -523,13 +545,14 @@ func TestGinAppAPI_Uninstall(t *testing.T) {
 
 	// Create test server and install an app
 	server := createGinTestServer(t, tempDir)
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
 
-    appDef := &api.AppDefinition{
-        Name:  "test-app",
-        Image: "alpine:latest",
-        Type:  "user",
-        Listeners: []api.AppListener{{Name:"web", GuestPort:80}},
-    }
+	appDef := &api.AppDefinition{
+		Name:      "test-app",
+		Image:     "alpine:latest",
+		Type:      "user",
+		Listeners: []api.AppListener{{Name: "web", GuestPort: 80}},
+	}
 
 	_, err = server.appManager.Install(context.Background(), appDef)
 	if err != nil {
@@ -539,6 +562,7 @@ func TestGinAppAPI_Uninstall(t *testing.T) {
 	// Test successful uninstall
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("DELETE", "/api/v1/apps/test-app", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
@@ -567,6 +591,7 @@ func TestGinAppAPI_Uninstall(t *testing.T) {
 	// Test uninstall non-existent app
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("DELETE", "/api/v1/apps/nonexistent", nil)
+	attachAuth(req, sessionCookie, csrfToken)
 	server.router.ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -586,6 +611,7 @@ func TestInvalidRoutes(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	server := createGinTestServer(t, tempDir)
+	sessionCookie, csrfToken := setupTestAdminSession(t, server)
 
 	tests := []struct {
 		name           string
@@ -593,12 +619,12 @@ func TestInvalidRoutes(t *testing.T) {
 		url            string
 		expectedStatus int
 	}{
-            {
-                name:           "empty app name",
-                method:         "GET",
-                url:            "/api/v1/apps/",
-                expectedStatus: http.StatusNotFound, // Trailing slash redirect disabled; expect 404
-            },
+		{
+			name:           "empty app name",
+			method:         "GET",
+			url:            "/api/v1/apps/",
+			expectedStatus: http.StatusNotFound, // Trailing slash redirect disabled; expect 404
+		},
 		{
 			name:           "too many path segments",
 			method:         "POST",
@@ -611,6 +637,7 @@ func TestInvalidRoutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req, _ := http.NewRequest(tt.method, tt.url, nil)
+			attachAuth(req, sessionCookie, csrfToken)
 			server.router.ServeHTTP(w, req)
 
 			if w.Code != tt.expectedStatus {
@@ -620,7 +647,6 @@ func TestInvalidRoutes(t *testing.T) {
 	}
 }
 
-
 // createGinTestServer creates a Gin test server instance with filesystem state management
 func createGinTestServer(t *testing.T, tempDir string) *GinServer {
 	// Create mock container manager for app manager
@@ -628,23 +654,114 @@ func createGinTestServer(t *testing.T, tempDir string) *GinServer {
 		containers: make(map[string]*MockContainer),
 		nextID:     1,
 	}
-	
-    // Create filesystem app manager with service manager
-    svcMgr := services.NewServiceManager()
-    appMgr, err := app.NewFSManagerWithServices(mockContainer, tempDir, svcMgr)
-    if err != nil {
-        t.Fatalf("Failed to create app manager: %v", err)
-    }
-	
+
+	// Create filesystem app manager with service manager
+	svcMgr := services.NewServiceManager()
+	appMgr, err := app.NewFSManagerWithServices(mockContainer, tempDir, svcMgr)
+	if err != nil {
+		t.Fatalf("Failed to create app manager: %v", err)
+	}
+
+	// Supporting managers for auth and crypto
+	authMgr, err := authpkg.NewManager(tempDir)
+	if err != nil {
+		t.Fatalf("auth manager init: %v", err)
+	}
+	cryptoMgr, err := crypt.NewManager(tempDir)
+	if err != nil {
+		t.Fatalf("crypto manager init: %v", err)
+	}
+
 	// Create minimal server instance for testing
-    rm, err := remote.NewManager(tempDir)
-    if err != nil { t.Fatalf("remote mgr: %v", err) }
-    server := &GinServer{appManager: appMgr, serviceManager: svcMgr, remoteManager: rm, version: "test-gin"}
-	
+	rm, err := remote.NewManager(tempDir)
+	if err != nil {
+		t.Fatalf("remote mgr: %v", err)
+	}
+	server := &GinServer{
+		appManager:     appMgr,
+		serviceManager: svcMgr,
+		remoteManager:  rm,
+		authManager:    authMgr,
+		sessions:       authpkg.NewSessionStore(),
+		cryptoManager:  cryptoMgr,
+		version:        "test-gin",
+	}
+
 	// Setup Gin routes
 	server.setupGinRoutes()
-	
+
 	return server
+}
+
+// setupTestAdminSession provisions the admin password and returns session cookie/CSRF token.
+func setupTestAdminSession(t *testing.T, server *GinServer) (*http.Cookie, string) {
+	t.Helper()
+	const password = "TestPass123!"
+
+	// First-run setup
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/auth/setup", strings.NewReader(fmt.Sprintf(`{"password":"%s"}`, password)))
+	req.Header.Set("Content-Type", "application/json")
+	server.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		// Allow already-initialized if tests re-use the helper on same server
+		if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "already") {
+			t.Fatalf("auth setup failed: status=%d body=%s", w.Code, w.Body.String())
+		}
+	}
+
+	// Login to obtain session cookie
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(fmt.Sprintf(`{"username":"admin","password":"%s"}`, password)))
+	req.Header.Set("Content-Type", "application/json")
+	server.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("auth login failed: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var sessionCookie *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == sessionCookieName {
+			sessionCookie = c
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatalf("missing session cookie in login response")
+	}
+
+	// Fetch CSRF token
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest(http.MethodGet, "/api/v1/auth/csrf", nil)
+	req.AddCookie(sessionCookie)
+	server.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("csrf fetch failed: status=%d body=%s", w.Code, w.Body.String())
+	}
+	var csrfResp struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &csrfResp); err != nil {
+		t.Fatalf("parse csrf response: %v", err)
+	}
+	if csrfResp.Token == "" {
+		t.Fatalf("csrf token empty")
+	}
+
+	return sessionCookie, csrfResp.Token
+}
+
+// attachAuth applies session cookie and CSRF header when required for the request.
+func attachAuth(req *http.Request, cookie *http.Cookie, csrfToken string) {
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	switch req.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return
+	}
+	if csrfToken != "" {
+		req.Header.Set("X-CSRF-Token", csrfToken)
+	}
 }
 
 // MockContainer represents a mock container for testing
@@ -663,19 +780,19 @@ func generateMockContainerID(id int) string {
 
 // GinMockContainerManager implements the ContainerManager interface for Gin testing
 type GinMockContainerManager struct {
-    containers map[string]*MockContainer
-    nextID     int
-    createError   error
-    startError    error
-    stopError     error
-    removeError   error
+	containers  map[string]*MockContainer
+	nextID      int
+	createError error
+	startError  error
+	stopError   error
+	removeError error
 }
 
 func (m *GinMockContainerManager) CreateContainer(ctx context.Context, spec container.ContainerCreateSpec) (string, error) {
 	if m.createError != nil {
 		return "", m.createError
 	}
-	
+
 	// Initialize containers map if nil (safety check)
 	if m.containers == nil {
 		m.containers = make(map[string]*MockContainer)
@@ -699,7 +816,7 @@ func (m *GinMockContainerManager) StartContainer(ctx context.Context, containerI
 	if m.startError != nil {
 		return m.startError
 	}
-	
+
 	if container, exists := m.containers[containerID]; exists {
 		container.Status = "running"
 		return nil
@@ -711,7 +828,7 @@ func (m *GinMockContainerManager) StopContainer(ctx context.Context, containerID
 	if m.stopError != nil {
 		return m.stopError
 	}
-	
+
 	if container, exists := m.containers[containerID]; exists {
 		container.Status = "stopped"
 		return nil
@@ -723,7 +840,7 @@ func (m *GinMockContainerManager) RemoveContainer(ctx context.Context, container
 	if m.removeError != nil {
 		return m.removeError
 	}
-	
+
 	if _, exists := m.containers[containerID]; exists {
 		delete(m.containers, containerID)
 		return nil
@@ -732,15 +849,19 @@ func (m *GinMockContainerManager) RemoveContainer(ctx context.Context, container
 }
 
 func (m *GinMockContainerManager) PullImage(ctx context.Context, image string) error {
-    return nil
+	return nil
 }
 
 func (m *GinMockContainerManager) Logs(ctx context.Context, containerID string, lines int) ([]string, error) {
-    if _, ok := m.containers[containerID]; !ok {
-        return nil, container.ErrContainerNotFound(containerID)
-    }
-    if lines <= 0 { lines = 2 }
-    out := []string{}
-    for i := 0; i < lines; i++ { out = append(out, "demo log entry") }
-    return out, nil
+	if _, ok := m.containers[containerID]; !ok {
+		return nil, container.ErrContainerNotFound(containerID)
+	}
+	if lines <= 0 {
+		lines = 2
+	}
+	out := []string{}
+	for i := 0; i < lines; i++ {
+		out = append(out, "demo log entry")
+	}
+	return out, nil
 }

--- a/src/l1/piccolod/internal/server/gin_app_phase3_test.go
+++ b/src/l1/piccolod/internal/server/gin_app_phase3_test.go
@@ -1,32 +1,50 @@
 package server
 
 import (
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "testing"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
 )
 
 func TestAppPhase3_EndpointsReturnOK(t *testing.T) {
-    srv := createGinTestServer(t, t.TempDir())
+	srv := createGinTestServer(t, t.TempDir())
+	sessionCookie, csrfToken := setupTestAdminSession(t, srv)
 
-    // Logs endpoint for non-existing app in demo should still return 200
-    os.Setenv("PICCOLO_DEMO", "1")
-    t.Cleanup(func(){ os.Unsetenv("PICCOLO_DEMO") })
+	// Logs endpoint for non-existing app in demo should still return 200
+	os.Setenv("PICCOLO_DEMO", "1")
+	t.Cleanup(func() { os.Unsetenv("PICCOLO_DEMO") })
 
-    w := httptest.NewRecorder()
-    req, _ := http.NewRequest("GET", "/api/v1/apps/demo/logs", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("logs status %d", w.Code) }
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/apps/demo/logs", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("logs status %d", w.Code)
+	}
 
-    // Update/revert endpoints should 200 in demo
-    w = httptest.NewRecorder(); req, _ = http.NewRequest("POST", "/api/v1/apps/demo/update", nil)
-    srv.router.ServeHTTP(w, req); if w.Code != http.StatusOK { t.Fatalf("update status %d", w.Code) }
-    w = httptest.NewRecorder(); req, _ = http.NewRequest("POST", "/api/v1/apps/demo/revert", nil)
-    srv.router.ServeHTTP(w, req); if w.Code != http.StatusOK { t.Fatalf("revert status %d", w.Code) }
+	// Update/revert endpoints should 200 in demo
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/apps/demo/update", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update status %d", w.Code)
+	}
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/apps/demo/revert", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revert status %d", w.Code)
+	}
 
-    // Catalog
-    w = httptest.NewRecorder(); req, _ = http.NewRequest("GET", "/api/v1/catalog", nil)
-    srv.router.ServeHTTP(w, req); if w.Code != http.StatusOK { t.Fatalf("catalog status %d", w.Code) }
+	// Catalog
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/catalog", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("catalog status %d", w.Code)
+	}
 }
-

--- a/src/l1/piccolod/internal/server/gin_app_update_revert_real_test.go
+++ b/src/l1/piccolod/internal/server/gin_app_update_revert_real_test.go
@@ -1,60 +1,96 @@
 package server
 
 import (
-    "bytes"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestAppUpdateRevertAndLogs_RealHandlers(t *testing.T) {
-    srv := createGinTestServer(t, t.TempDir())
+	srv := createGinTestServer(t, t.TempDir())
+	sessionCookie, csrfToken := setupTestAdminSession(t, srv)
 
-    // Install via API
-    body := []byte("name: demo\nimage: alpine:3.18\ntype: user\nlisteners:\n - name: web\n   guest_port: 80\n")
-    w := httptest.NewRecorder()
-    req, _ := http.NewRequest("POST", "/api/v1/apps", bytes.NewReader(body))
-    req.Header.Set("Content-Type", "application/x-yaml")
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusCreated { t.Fatalf("install status %d body=%s", w.Code, w.Body.String()) }
+	// Install via API
+	body := []byte("name: demo\nimage: alpine:3.18\ntype: user\nlisteners:\n - name: web\n   guest_port: 80\n")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/apps", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-yaml")
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("install status %d body=%s", w.Code, w.Body.String())
+	}
 
-    // Update tag
-    w = httptest.NewRecorder()
-    payload := map[string]string{"tag":"3.19"}
-    pbytes, _ := json.Marshal(payload)
-    req, _ = http.NewRequest("POST", "/api/v1/apps/demo/update", bytes.NewReader(pbytes))
-    req.Header.Set("Content-Type", "application/json")
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("update status %d body=%s", w.Code, w.Body.String()) }
+	// Update tag
+	w = httptest.NewRecorder()
+	payload := map[string]string{"tag": "3.19"}
+	pbytes, _ := json.Marshal(payload)
+	req, _ = http.NewRequest("POST", "/api/v1/apps/demo/update", bytes.NewReader(pbytes))
+	req.Header.Set("Content-Type", "application/json")
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update status %d body=%s", w.Code, w.Body.String())
+	}
 
-    // Verify image changed
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("GET", "/api/v1/apps/demo", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("get after update %d", w.Code) }
-    var resp struct{ Data struct{ App struct{ Image string `json:"image"` } `json:"app"` } `json:"data"` }
-    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil { t.Fatal(err) }
-    if resp.Data.App.Image != "alpine:3.19" { t.Fatalf("expected alpine:3.19, got %s", resp.Data.App.Image) }
+	// Verify image changed
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/apps/demo", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("get after update %d", w.Code)
+	}
+	var resp struct {
+		Data struct {
+			App struct {
+				Image string `json:"image"`
+			} `json:"app"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Data.App.Image != "alpine:3.19" {
+		t.Fatalf("expected alpine:3.19, got %s", resp.Data.App.Image)
+	}
 
-    // Revert
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("POST", "/api/v1/apps/demo/revert", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("revert status %d body=%s", w.Code, w.Body.String()) }
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("GET", "/api/v1/apps/demo", nil)
-    srv.router.ServeHTTP(w, req)
-    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil { t.Fatal(err) }
-    if resp.Data.App.Image != "alpine:3.18" { t.Fatalf("expected alpine:3.18 after revert, got %s", resp.Data.App.Image) }
+	// Revert
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/apps/demo/revert", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revert status %d body=%s", w.Code, w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/apps/demo", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Data.App.Image != "alpine:3.18" {
+		t.Fatalf("expected alpine:3.18 after revert, got %s", resp.Data.App.Image)
+	}
 
-    // Logs
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("GET", "/api/v1/apps/demo/logs?tail=3", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("logs status %d", w.Code) }
-    var logs struct{ Entries []string `json:"entries"` }
-    if err := json.Unmarshal(w.Body.Bytes(), &logs); err != nil { t.Fatal(err) }
-    if len(logs.Entries) != 3 { t.Fatalf("expected 3 log entries, got %d", len(logs.Entries)) }
+	// Logs
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/apps/demo/logs?tail=3", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("logs status %d", w.Code)
+	}
+	var logs struct {
+		Entries []string `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &logs); err != nil {
+		t.Fatal(err)
+	}
+	if len(logs.Entries) != 3 {
+		t.Fatalf("expected 3 log entries, got %d", len(logs.Entries))
+	}
 }
-

--- a/src/l1/piccolod/internal/server/gin_remote_handlers_test.go
+++ b/src/l1/piccolod/internal/server/gin_remote_handlers_test.go
@@ -1,62 +1,91 @@
 package server
 
 import (
-    "bytes"
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 func TestRemote_Configure_Status_Disable_Rotate(t *testing.T) {
-    srv := createGinTestServer(t, t.TempDir())
+	srv := createGinTestServer(t, t.TempDir())
+	sessionCookie, csrfToken := setupTestAdminSession(t, srv)
 
-    // Initial status disabled
-    w := httptest.NewRecorder()
-    req, _ := http.NewRequest("GET", "/api/v1/remote/status", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("status %d", w.Code) }
+	// Initial status disabled
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/remote/status", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
 
-    // Configure
-    payload := map[string]string{
-        "endpoint": "https://nexus.example.com",
-        "device_id": "dev123",
-        "hostname": "host.example.com",
-    }
-    body, _ := json.Marshal(payload)
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("POST", "/api/v1/remote/configure", bytes.NewReader(body))
-    req.Header.Set("Content-Type", "application/json")
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("configure %d body=%s", w.Code, w.Body.String()) }
+	// Configure
+	payload := map[string]string{
+		"endpoint":  "https://nexus.example.com",
+		"device_id": "dev123",
+		"hostname":  "host.example.com",
+	}
+	body, _ := json.Marshal(payload)
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/remote/configure", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("configure %d body=%s", w.Code, w.Body.String())
+	}
 
-    // Status enabled
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("GET", "/api/v1/remote/status", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("status2 %d", w.Code) }
-    var st struct{ Enabled bool `json:"enabled"`; PublicURL *string `json:"public_url"` }
-    if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil { t.Fatal(err) }
-    if !st.Enabled || st.PublicURL == nil { t.Fatalf("expected enabled remote with url") }
+	// Status enabled
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/remote/status", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status2 %d", w.Code)
+	}
+	var st struct {
+		Enabled   bool    `json:"enabled"`
+		PublicURL *string `json:"public_url"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if !st.Enabled || st.PublicURL == nil {
+		t.Fatalf("expected enabled remote with url")
+	}
 
-    // Rotate
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("POST", "/api/v1/remote/rotate", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("rotate %d", w.Code) }
+	// Rotate
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/remote/rotate", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("rotate %d", w.Code)
+	}
 
-    // Disable
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("POST", "/api/v1/remote/disable", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("disable %d", w.Code) }
+	// Disable
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("POST", "/api/v1/remote/disable", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable %d", w.Code)
+	}
 
-    // Status disabled
-    w = httptest.NewRecorder()
-    req, _ = http.NewRequest("GET", "/api/v1/remote/status", nil)
-    srv.router.ServeHTTP(w, req)
-    if w.Code != http.StatusOK { t.Fatalf("status3 %d", w.Code) }
-    if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil { t.Fatal(err) }
-    if st.Enabled { t.Fatalf("expected disabled") }
+	// Status disabled
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/api/v1/remote/status", nil)
+	attachAuth(req, sessionCookie, csrfToken)
+	srv.router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status3 %d", w.Code)
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.Enabled {
+		t.Fatalf("expected disabled")
+	}
 }
-


### PR DESCRIPTION
## Summary
- move `/auth/initialized` into the OpenAPI `paths` section so the spec validates alongside other auth endpoints
- add helpers to bootstrap an authenticated session/CSRF token and apply them across Gin app tests so POST/DELETE routes execute under the new middleware
- require the same authenticated context for phase 3/demo and remote handler tests to keep coverage exercising the secured APIs

## Testing
- ✅ `go test ./internal/server`
- ✅ `go test ./docs/api`
- ⚠️ `go test ./...` *(fails in internal/mdns integration tests because the container lacks real network interfaces)*

------
https://chatgpt.com/codex/tasks/task_e_68c971df2b0c83319176cb61e1480644